### PR TITLE
add note about installing via bioconda in gh-pages

### DIFF
--- a/download.md
+++ b/download.md
@@ -31,6 +31,12 @@ and install __sleuth__ by typing
 devtools::install_github("pachterlab/sleuth")
 ~~~
 
+If you have [__conda__](http://conda.pydata.org/docs/), a cross-platform package manager installed, you can install __sleuth__ via the [__bioconda__](https://bioconda.github.io/) channel.
+
+~~~
+conda install --channel bioconda r-sleuth
+~~~
+
 Next load __sleuth__ with
 
 ~~~


### PR DESCRIPTION
As suggested (https://github.com/pachterlab/sleuth/pull/50), I've also added the installation note to the `gh-pages` branch.