### PR TITLE
workaround for dplyr issues using $ in mutate calls.

### DIFF
--- a/R/sleuth.R
+++ b/R/sleuth.R
@@ -264,9 +264,7 @@ sleuth_prep <- function(
     })
 
     # add in eff_len and len
-    obs_norm <- dplyr::mutate(obs_norm,
-      eff_len = obs_raw$eff_len,
-      len = obs_raw$len)
+    obs_norm = dplyr::bind_cols(obs_norm, dplyr::select(obs_raw, eff_len, len))
 
     msg("normalizing bootstrap samples")
     ret$kal <- lapply(seq_along(ret$kal), function(i) {


### PR DESCRIPTION
I was encountering an issue here:

```r
Browse[2]> head(obs_norm)
Source: local data frame [6 x 4]

        target_id   sample est_counts   tpm
            (chr)    (chr)      (dbl) (dbl)
1 ENST00000003583 sampleA1          0     0
2 ENST00000003583 sampleA2          0     0
3 ENST00000003583 sampleA3          0     0
4 ENST00000003583 sampleB1          0     0
5 ENST00000003583 sampleB2          0     0
6 ENST00000003583 sampleB3          0     0

Browse[2]> head(obs_raw)
Source: local data frame [6 x 6]

        target_id est_counts eff_len   len   tpm   sample
            (chr)      (dbl)   (dbl) (dbl) (dbl)    (chr)
1 ENST00000003583          0 2380.46  2544     0 sampleA1
2 ENST00000003583          0 2380.35  2544     0 sampleA2
3 ENST00000003583          0 2379.80  2544     0 sampleA3
4 ENST00000003583          0 2379.70  2544     0 sampleB1
5 ENST00000003583          0 2380.16  2544     0 sampleB2
6 ENST00000003583          0 2379.67  2544     0 sampleB3

debug: obs_norm <- dplyr::mutate(obs_norm, eff_len = obs_raw$eff_len,
    len = obs_raw$len)

Browse[2]> n
Error: invalid subscript type 'integer'
```

I think dplyr and $ doesn't always work correctly (https://github.com/hadley/dplyr/issues/1400) so I swapped it to drop the conflicting columns from `obs_raw` and use `join` instead.