### PR TITLE
Update sleuth.R

### DIFF
--- a/R/sleuth.R
+++ b/R/sleuth.R
@@ -510,7 +510,7 @@ spread_abundance_by <- function(abund, var, which_order) {
 
   result <- as.matrix(var_spread)
 
-  result[, which_order]
+  result[, which_order, drop=FALSE]
 }
 
 #' @export


### PR DESCRIPTION
Prevent dropping of dimensions in spread_abundance_by when only 1 sample is used. 
When the dimension is dropped, it results in an error in subsequent code.