### PR TITLE
Issues #80 and #81: reduce 'mclapply' memory footprint; add "num_cores" option

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -145,7 +145,7 @@ aggregate_bootstrap <- function(kal, mapping, split_by = "gene_id",
 
   if ( any(!complete.cases(mapping)) ) {
     warning("Found some NAs in mapping. Removing them.")
-    mapping <- mapping[complete.cases(mapping),]
+    mapping <- mapping[complete.cases(mapping), ]
   }
 
   m_bs <- melt_bootstrap(kal, column)
@@ -275,8 +275,8 @@ sample_bootstrap <- function(obj, n_samples = 100L) {
   # matrix sample
   for (s in 1:n_samples) {
     for (idx in 1:nrow(which_samp)) {
-      b <- which_samp[idx,s]
-      sample_mat[[s]][,idx] <- obj$kal[[idx]]$bootstrap[[b]]$est_counts
+      b <- which_samp[idx, s]
+      sample_mat[[s]][, idx] <- obj$kal[[idx]]$bootstrap[[b]]$est_counts
     }
   }
 
@@ -318,7 +318,7 @@ dcast_bootstrap.kallisto <- function(obj, units, nsamples = NULL) {
   mat <- matrix(NA_real_, nrow = n_features, ncol = length(which_bs))
 
   for (j in seq_along(which_bs)) {
-    mat[ ,j] <- obj[[ "bootstrap" ]][[which_bs[j]]][[ units ]]
+    mat[, j] <- obj[[ "bootstrap" ]][[which_bs[j]]][[ units ]]
   }
   rownames(mat) <- obj[["bootstrap"]][[1]][["target_id"]]
 

--- a/R/gene_analysis.R
+++ b/R/gene_analysis.R
@@ -1,8 +1,8 @@
 propagate_transcript_filter <- function(filter_df, target_mapping,
   grouping_column) {
 
-  filtered_target_mapping <- dplyr::inner_join(as.data.table(filter_df),
-    as.data.table(target_mapping), by = 'target_id')
+  filtered_target_mapping <- dplyr::inner_join(as.data.table(filter_df), # nolint
+    as.data.table(target_mapping), by = 'target_id') # nolint
 
   filtered_target_mapping <- dplyr::select_(filtered_target_mapping,
     grouping_column)

--- a/R/measurement_error.R
+++ b/R/measurement_error.R
@@ -113,7 +113,7 @@ sleuth_fit <- function(obj, formula = NULL, fit_name = NULL, ...) {
   msg('computing variance of betas')
   beta_covars <- lapply(1:nrow(l_smooth),
     function(i) {
-      row <- l_smooth[i,]
+      row <- l_smooth[i, ]
       with(row,
           covar_beta(smooth_sigma_sq_pmax + sigma_q_sq, X, A)
         )
@@ -267,7 +267,7 @@ me_model_by_row <- function(obj, design, bs_summary) {
 
   models <- lapply(1:nrow(bs_summary$obs_counts),
     function(i) {
-      me_model(design, bs_summary$obs_counts[i,], bs_summary$sigma_q_sq[i])
+      me_model(design, bs_summary$obs_counts[i, ], bs_summary$sigma_q_sq[i])
     })
   names(models) <- rownames(bs_summary$obs_counts)
 
@@ -303,7 +303,7 @@ me_heteroscedastic_by_row <- function(obj, design, samp_bs_summary, obs_counts) 
 
   models <- lapply(1:nrow(bs_summary$obs_counts),
     function(i) {
-      res <- me_white_model(design, obs_counts[i,], sigma_q_sq[i,], A)
+      res <- me_white_model(design, obs_counts[i, ], sigma_q_sq[i, ], A)
       res$df$target_id <- rownames(obs_counts)[i]
       res
     })
@@ -429,7 +429,7 @@ reads_per_base_transform <- function(reads_table, scale_factor_input,
   as_df(reads_table)
 }
 
-gene_summary <- function(obj, which_column, transform = identity, 
+gene_summary <- function(obj, which_column, transform = identity,
                          norm_by_length = TRUE, num_cores=2) {
   # stopifnot(is(obj, 'sleuth'))
   msg(paste0('aggregating by column: ', which_column))
@@ -469,7 +469,7 @@ gene_summary <- function(obj, which_column, transform = identity,
         b <- dplyr::mutate(b, sample = current_sample)
         reads_per_base_transform(b, scale_factor, which_column,
           obj$target_mapping, norm_by_length)
-      }, mc.cores=num_cores)
+      }, mc.cores = num_cores)
 
       k
     })

--- a/R/misc.R
+++ b/R/misc.R
@@ -25,7 +25,7 @@ get_quantile <- function(data, which_col, lwr, upr, ignore_zeroes = TRUE) {
   data$iqr <- valid
 
   if (ignore_zeroes) {
-    valid <- data[,which_col] > 0
+    valid <- data[, which_col] > 0
     if (sum(valid) == 0) {
       # in this case, everything in this bin is zero, so we just return the
       # entire bin
@@ -36,7 +36,7 @@ get_quantile <- function(data, which_col, lwr, upr, ignore_zeroes = TRUE) {
     data$iqr[!valid] <- FALSE
   }
 
-  data$iqr[valid] <- data[valid,which_col] %>%
+  data$iqr[valid] <- data[valid, which_col] %>%
     ecdf(.)(.) %>%
     ifelse(lwr <= . & . <= upr)
 
@@ -49,7 +49,7 @@ sliding_window_grouping <- function(data, x_col, y_col,
 
   data <- as.data.frame(data)
 
-  data <- mutate(data,x_ecdf = ecdf(data[,x_col])(data[,x_col]))
+  data <- mutate(data, x_ecdf = ecdf(data[, x_col])(data[, x_col]))
   data <- mutate(data, x_group = cut(x_ecdf, n_bins))
   data <- group_by(data, x_group)
 
@@ -63,7 +63,7 @@ sliding_window_grouping <- function(data, x_col, y_col,
 shrink_df <- function(data, shrink_formula, filter_var) {
   data <- as.data.frame(data)
   s_formula <- substitute(shrink_formula)
-  fit <- eval(loess(s_formula, data[data[,filter_var],]))
+  fit <- eval(loess(s_formula, data[data[, filter_var], ]))
   data.frame(data, shrink = predict(fit, data))
 }
 
@@ -119,17 +119,17 @@ apply_all_pairs <- function(mat, fun) {
 
   all_pairs <- utils::combn(ids, 2)
   for (i in 1:ncol(all_pairs)) {
-    j <- all_pairs[1,i]
-    k <- all_pairs[2,i]
+    j <- all_pairs[1, i]
+    k <- all_pairs[2, i]
 
-    cur <- fun(mat[,j], mat[,k])
+    cur <- fun(mat[, j], mat[, k])
 
-    res[j,k] <- cur
-    res[k,j] <- cur
+    res[j, k] <- cur
+    res[k, j] <- cur
   }
 
   for (i in 1:length(ids)) {
-    res[i,i] <- fun(mat[,i], mat[,i])
+    res[i, i] <- fun(mat[, i], mat[, i])
   }
 
 

--- a/R/model.R
+++ b/R/model.R
@@ -54,7 +54,7 @@ models.sleuth <- function(obj, verbose = TRUE) {
   # TODO: output a new in between models for readability
   if (verbose) {
     for (x in names(obj$fits)) {
-      cat('[ ', x,' ]\n')
+      cat('[ ', x, ' ]\n')
       models(obj$fits[[x]])
     }
   }

--- a/R/plots.R
+++ b/R/plots.R
@@ -174,7 +174,7 @@ plot_loadings <- function(obj,
   #given a sample
   if (!is.null(sample)) {
     toggle <- TRUE
-    loadings <- pca_calc$x[sample,]
+    loadings <- pca_calc$x[sample, ]
     if (pca_loading_abs) {
       loadings <- abs(loadings)
       loadings <- sort(loadings, decreasing = TRUE)
@@ -185,7 +185,7 @@ plot_loadings <- function(obj,
 
   #given a PC, which samples contribute the most?
   if (!toggle) {
-    loadings <- pca_calc$x[,pc_input]
+    loadings <- pca_calc$x[, pc_input]
     if (pca_loading_abs) {
       loadings <- abs(loadings)
       loadings <- sort(loadings, decreasing = TRUE)
@@ -272,14 +272,14 @@ plot_pc_variance <- function(obj,
   }
   pc_df <- data.frame(PC_count = 1:colsize, var = var_explained) #order here matters
 
-  if(!is.null(PC_relative)) {
+  if (!is.null(PC_relative)) {
     pc_df <- data.frame(PC_count = 1:length(eigenvalues), var = var_explained2)
-    pc_df <- pc_df[PC_relative:nrow(pc_df),]
+    pc_df <- pc_df[PC_relative:nrow(pc_df), ]
 
     if (!is.null(pca_number) && (PC_relative + pca_number <= length(eigenvalues))) {
-      pc_df <- pc_df[1:pca_number,]
+      pc_df <- pc_df[1:pca_number, ]
     } else if (PC_relative + 5 >= length(eigenvalues)) {
-      pc_df <- pc_df[1:nrow(pc_df),]
+      pc_df <- pc_df[1:nrow(pc_df), ]
     }
   }
 
@@ -874,15 +874,15 @@ plot_transcript_heatmap <- function(obj,
   units = 'tpm',
   trans = 'log',
   offset = 1) {
-  if(!all(transcripts %in% obj$obs_norm$target_id)) {
+  if (!all(transcripts %in% obj$obs_norm$target_id)) {
     stop("Couldn't find the following transcripts: ",
       paste(transcripts[!(transcripts %in% obj$obs_norm$target_id)], collapse = ", "),
       "\n\tIt is highly likely that some of them were filtered out.")
   }
 
-  tabd_df <- obj$obs_norm[obj$obs_norm$target_id %in% transcripts,]
+  tabd_df <- obj$obs_norm[obj$obs_norm$target_id %in% transcripts, ]
 
-  if(units == 'tpm') {
+  if (units == 'tpm') {
     tabd_df <- dplyr::select(tabd_df, target_id, sample, tpm)
     tabd_df <- reshape2::dcast(tabd_df, target_id ~sample, value.var = 'tpm')
   } else if (units == 'est_counts') {
@@ -948,16 +948,16 @@ ggPlotExpression <- function(exMat, clustRows = TRUE, clustCols = TRUE,
      legend.direction = 'vertical',
      legend.position = 'top',
      legend.background = element_rect(fill = "gray95", colour = "black", size = 0.5, linetype = 1),
-     axis.title=element_blank())
+     axis.title = element_blank())
     if (rowNames)
-        p <- p + theme(axis.text.x=element_text(angle = 90, size=14))
+        p <- p + theme(axis.text.x = element_text(angle = 90, size = 14))
     else
-        p <- p + theme(axis.text.x=element_text(size=0))
+        p <- p + theme(axis.text.x = element_text(size = 0))
 
     if (colNames)
-        p <- p + theme(axis.text.y=element_text(size=14))
+        p <- p + theme(axis.text.y = element_text(size = 14))
     else
-        p <- p + theme(axis.text.y=element_text(size=0))
+        p <- p + theme(axis.text.y = element_text(size = 0))
 
     p
     #list(plot = p, rowOrder = rowOrder, colOrder = colOrder)

--- a/R/read_write.R
+++ b/R/read_write.R
@@ -273,7 +273,7 @@ gtf_gene_names <- function(gtf_attr) {
 
   for (i in 1:length(all_attr)) {
     j <- 1
-    while ((nchar(gene_id[i]) < 1 || nchar(trans_id[i]) < 1) &&
+    while ( (nchar(gene_id[i]) < 1 || nchar(trans_id[i]) < 1) &&
       j <= length(all_attr[[i]]) ) {
       if (all_attr[[i]][j] == "gene_id") {
         gene_id[i] <- all_attr[[i]][j + 1] %>%

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -150,7 +150,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
             textInput('hm_transcripts', label = 'enter target ids: ', value = '')
               ),
           column(3,
-            selectInput('hm_units', label = 'units:', choices = c('est_counts','tpm'), selected = 'tpm')
+            selectInput('hm_units', label = 'units:', choices = c('est_counts', 'tpm'), selected = 'tpm')
               ),
           column(3,
             textInput('hm_trans', label = 'tranform: ', value = 'log')
@@ -161,7 +161,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
             actionButton('hm_go', 'view')
           )
         ),
-        tags$style(type='text/css', "#hm_go {margin-top: 25px}"),
+        tags$style(type = 'text/css', "#hm_go {margin-top: 25px}"),
         fluidRow(plotOutput('hm_plot')),
         fluidRow(uiOutput("download_hm_plt_button"))
     ),
@@ -1235,7 +1235,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
       result
     })
     output$table_type <- renderUI({
-      if(!is.null(obj$target_mapping)) {
+      if (!is.null(obj$target_mapping)) {
         selectInput('pop_genes', label = 'table type: ',
           choices = list('target table' = 1, 'gene table' = 2),
           selected = 1)
@@ -1243,7 +1243,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
     })
 
     output$group_by <- renderUI({
-      if(!is.null(input$pop_genes) && input$pop_genes == 2) {
+      if (!is.null(input$pop_genes) && input$pop_genes == 2) {
         selectInput('mappingGroup',
           label = 'group by: ',
           choices = names(obj$target_mapping)[2:length(names(obj$target_mapping))])
@@ -1258,7 +1258,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
         wb <- possible_tests[1]
       }
 
-      if(!is.null(input$mappingGroup) && (input$pop_genes == 2)) {
+      if (!is.null(input$mappingGroup) && (input$pop_genes == 2)) {
           mg <- input$mappingGroup
           test_table <- sleuth_gene_table(obj, wb, input$settings_test_type,
             input$which_model_de, mg)
@@ -1291,7 +1291,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
         possible_tests <- list_tests(obj, input$settings_test_type)
         which_test <- possible_tests[1]
       }
-      if(!is.null(input$mapping_group_lrt) && (input$pop_genes_lrt == 2)) {
+      if (!is.null(input$mapping_group_lrt) && (input$pop_genes_lrt == 2)) {
           mg <- input$mapping_group_lrt
           sleuth_gene_table(obj, which_test, input$settings_test_type,
             which_group = mg)
@@ -1301,14 +1301,14 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
     })
 
     output$table_type_lrt <- renderUI({
-      if(!is.null(obj$target_mapping)) {
+      if (!is.null(obj$target_mapping)) {
         selectInput('pop_genes_lrt', label = 'table type: ',
           choices = list('transcript table' = 1, 'gene table' = 2),
           selected = 1)
       }
     })
     output$group_by_lrt <- renderUI({
-      if(!is.null(input$pop_genes_lrt) && input$pop_genes_lrt == 2) {
+      if (!is.null(input$pop_genes_lrt) && input$pop_genes_lrt == 2) {
         selectInput('mapping_group_lrt',
           label = 'group by: ',
           choices = names(obj$target_mapping)[2:length(names(obj$target_mapping))])
@@ -1345,13 +1345,13 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
     ### Gene Viewer
     # the name of the gene supplied
     gv_var_text <- eventReactive(input$gv_go, {
-      if(!is.null(obj$target_mapping)) {
+      if (!is.null(obj$target_mapping)) {
           input$gv_var_input
       }
     })
 
     output$gv_gene_column <- renderUI({
-      if(!is.null(obj$target_mapping)) {
+      if (!is.null(obj$target_mapping)) {
         selectInput('gv_gene_colname',
           label = 'genes from: ',
           choices = names(obj$target_mapping)[2:length(names(obj$target_mapping))])
@@ -1388,7 +1388,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
     output$gv_var_plts <- renderUI({
       gv_plot_list <- lapply(1:input$gv_maxplots,
         function(i) {
-          gv_plotname <- paste("plot", i, sep="")
+          gv_plotname <- paste("plot", i, sep = "")
           plotOutput(gv_plotname)
         })
 
@@ -1398,9 +1398,9 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
       for (i in 1:15) {
         local({
           my_i <- i
-          gv_plotname <- paste("plot", my_i, sep="")
+          gv_plotname <- paste("plot", my_i, sep = "")
             output[[gv_plotname]] <- renderPlot({
-               if(!is.null(obj$target_mapping) && !is.na(gv_var_list()[my_i])) {
+               if (!is.null(obj$target_mapping) && !is.na(gv_var_list()[my_i])) {
                  plot_bootstrap(obj,
                    gv_var_list()[my_i],
                    units = input$gv_var_units,
@@ -1411,7 +1411,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
         }
 
     output$no_genes_message <- renderUI({
-      if(is.null(obj$target_mapping)) {
+      if (is.null(obj$target_mapping)) {
         HTML('&nbsp&nbsp&nbsp&nbspYou need to add genes to your sleuth object to use the gene viewer.<br>',
         '&nbsp&nbsp&nbsp&nbspTo add genes to your sleuth object, see the ',
         '<a href = "http://pachterlab.github.io/sleuth/starting.html">sleuth getting started guide</a>.')
@@ -1426,7 +1426,7 @@ sleuth_live <- function(obj, settings = sleuth_live_settings(),
     default_hm_plot_height <- 400
 
     hm_plot_height <- function() {
-        if(length(hm_transcripts()) > 5) {
+        if (length(hm_transcripts()) > 5) {
             length(hm_transcripts()) * 60
         } else {
             default_hm_plot_height
@@ -1566,7 +1566,7 @@ enclosed_brush <- function(df, brush) {
   xbool <- brush$xmin <= df[[xvar]] & df[[xvar]] <= brush$xmax
   ybool <- brush$ymin <= df[[yvar]] & df[[yvar]] <= brush$ymax
 
-  df[xbool & ybool,]
+  df[xbool & ybool, ]
 }
 
 #' settings for sleuth_live

--- a/R/sleuth.R
+++ b/R/sleuth.R
@@ -104,7 +104,7 @@ sleuth_prep <- function(
   norm_fun_counts = norm_factors,
   norm_fun_tpm = norm_factors,
   aggregation_column = NULL,
-  num_cores = 2,
+  num_cores = 2L,
   ...) {
 
   ##############################
@@ -165,7 +165,8 @@ sleuth_prep <- function(
     stop("You provided a 'aggregation_column' to aggregate by, but not a 'target_mapping'. Please provided a 'target_mapping'.")
   }
 
-  if ( !is.integer(num_cores) || num_cores < 1 || num_cores > parallel::detectCores()) {
+  if ( is.null(num_cores) || is.na(suppressWarnings(as.integer(num_cores)) || 
+       num_cores < 1 || num_cores > parallel::detectCores()) {
     stop("num_cores must be an integer between 1 and the number of cores on your machine")
   }
 

--- a/R/sleuth.R
+++ b/R/sleuth.R
@@ -112,7 +112,7 @@ sleuth_prep <- function(
 
   # data types
 
-  if (!is(sample_to_covariates, "data.frame") ) {
+  if (!is(sample_to_covariates, "data.frame")) {
     stop(paste0("'", substitute(sample_to_covariates), "' (sample_to_covariates) must be a data.frame"))
   }
 
@@ -144,24 +144,24 @@ sleuth_prep <- function(
     stop("max_bootstrap must be > 0")
   }
 
-  if (any(is.na(sample_to_covariates)) ) {
+  if (any(is.na(sample_to_covariates))) {
     warning("Your 'sample_to_covariance' data.frame contains NA values. This will likely cause issues later.")
   }
 
   if (is(full_model, "matrix") &&
-      nrow(full_model) != nrow(sample_to_covariates) ) {
+      nrow(full_model) != nrow(sample_to_covariates)) {
     stop("The design matrix number of rows are not equal to the number of rows in the sample_to_covariates argument.")
   }
 
-  if (!is(norm_fun_counts, 'function') ) {
+  if (!is(norm_fun_counts, 'function')) {
     stop("norm_fun_counts must be a function")
   }
 
-  if (!is(norm_fun_tpm, 'function') ) {
+  if (!is(norm_fun_tpm, 'function')) {
     stop("norm_fun_tpm must be a function")
   }
 
-  if (!is.null(aggregation_column) && is.null(target_mapping) ) {
+  if (!is.null(aggregation_column) && is.null(target_mapping)) {
     stop(paste("You provided a 'aggregation_column' to aggregate by,",
                "but not a 'target_mapping'. Please provided a 'target_mapping'."))
   }
@@ -209,10 +209,10 @@ sleuth_prep <- function(
   obs_raw <- dplyr::bind_rows(lapply(kal_list, function(k) k$abundance))
 
   design_matrix <- NULL
-  if (is(full_model, 'formula') ) {
+  if (is(full_model, 'formula')) {
     design_matrix <- model.matrix(full_model, sample_to_covariates)
   } else {
-    if (is.null(colnames(full_model)) ) {
+    if (is.null(colnames(full_model))) {
       stop("If matrix is supplied, column names must also be supplied.")
     }
     design_matrix <- full_model
@@ -283,11 +283,11 @@ sleuth_prep <- function(
     tpm_norm <- dplyr::arrange(tpm_norm, target_id, sample)
 
     stopifnot(all.equal(obs_raw$target_id, obs_norm$target_id) &&
-      all.equal(obs_raw$sample, obs_norm$sample) )
+      all.equal(obs_raw$sample, obs_norm$sample))
 
     suppressWarnings({
       if (!all.equal(dplyr::select(obs_norm, target_id, sample),
-          dplyr::select(tpm_norm, target_id, sample)) ) {
+          dplyr::select(tpm_norm, target_id, sample))) {
         stop('Invalid column rows. In principle, can simply join. Please report error.')
       }
 
@@ -439,7 +439,7 @@ norm_factors <- function(mat) {
   nz <- apply(mat, 1, function(row) !any(round(row) == 0))
   mat_nz <- mat[nz, ]
   p <- ncol(mat)
-  geo_means <- exp(apply(mat_nz, 1, function(row) mean(log(row)) ))
+  geo_means <- exp(apply(mat_nz, 1, function(row) mean(log(row))))
   s <- sweep(mat_nz, 1, geo_means, `/`)
 
   sf <- apply(s, 2, median)

--- a/R/sleuth.R
+++ b/R/sleuth.R
@@ -34,7 +34,7 @@ filter_df_all_groups <- function(df, fun, group_df, ...) {
   grps <- setdiff(colnames(group_df), 'sample')
   res <- sapply(unique(grps),
     function(g) {
-      apply(filter_df_by_groups(df, fun, group_df[,c('sample', g)], ...), 1, any)
+      apply(filter_df_by_groups(df, fun, group_df[, c('sample', g)], ...), 1, any)
     })
 
   vals <- apply(res, 1, any)
@@ -51,7 +51,7 @@ filter_df_by_groups <- function(df, fun, group_df, ...) {
     function(g) {
       valid_samps <- grps %in% g
       valid_samps <- group_df$sample[valid_samps]
-      apply(df[,valid_samps], 1, fun, ...)
+      apply(df[, valid_samps], 1, fun, ...)
     })
 }
 
@@ -112,12 +112,12 @@ sleuth_prep <- function(
 
   # data types
 
-  if ( !is(sample_to_covariates, "data.frame") ) {
+  if (!is(sample_to_covariates, "data.frame") ) {
     stop(paste0("'", substitute(sample_to_covariates), "' (sample_to_covariates) must be a data.frame"))
   }
 
   if (!is(full_model, "formula") && !is(full_model, "matrix")) {
-    stop(paste0("'",substitute(full_model), "' (full_model) must be a formula or a matrix"))
+    stop(paste0("'", substitute(full_model), "' (full_model) must be a formula or a matrix"))
   }
 
   if (!("sample" %in% colnames(sample_to_covariates))) {
@@ -130,7 +130,7 @@ sleuth_prep <- function(
       "' (sample_to_covariates) must contain a column named 'path'")
   }
 
-  if ( !is.null(target_mapping) && !is(target_mapping, 'data.frame')) {
+  if (!is.null(target_mapping) && !is(target_mapping, 'data.frame')) {
     stop(paste0("'", substitute(target_mapping),
         "' (target_mapping) must be a data.frame or NULL"))
   } else if (is(target_mapping, 'data.frame')){
@@ -140,32 +140,33 @@ sleuth_prep <- function(
     }
   }
 
-  if ( !is.null(max_bootstrap) && max_bootstrap <= 0 ) {
+  if (!is.null(max_bootstrap) && max_bootstrap <= 0 ) {
     stop("max_bootstrap must be > 0")
   }
 
-  if ( any(is.na(sample_to_covariates)) ) {
+  if (any(is.na(sample_to_covariates)) ) {
     warning("Your 'sample_to_covariance' data.frame contains NA values. This will likely cause issues later.")
   }
 
-  if ( is(full_model, "matrix") &&
+  if (is(full_model, "matrix") &&
       nrow(full_model) != nrow(sample_to_covariates) ) {
     stop("The design matrix number of rows are not equal to the number of rows in the sample_to_covariates argument.")
   }
 
-  if ( !is(norm_fun_counts, 'function') ) {
+  if (!is(norm_fun_counts, 'function') ) {
     stop("norm_fun_counts must be a function")
   }
 
-  if ( !is(norm_fun_tpm, 'function') ) {
+  if (!is(norm_fun_tpm, 'function') ) {
     stop("norm_fun_tpm must be a function")
   }
 
-  if ( !is.null(aggregation_column) && is.null(target_mapping) ) {
-    stop("You provided a 'aggregation_column' to aggregate by, but not a 'target_mapping'. Please provided a 'target_mapping'.")
+  if (!is.null(aggregation_column) && is.null(target_mapping) ) {
+    stop(paste("You provided a 'aggregation_column' to aggregate by,",
+               "but not a 'target_mapping'. Please provided a 'target_mapping'."))
   }
 
-  if ( is.null(num_cores) || is.na(suppressWarnings(as.integer(num_cores)) || 
+  if (is.null(num_cores) || is.na(suppressWarnings(as.integer(num_cores))) ||
        num_cores < 1 || num_cores > parallel::detectCores()) {
     stop("num_cores must be an integer between 1 and the number of cores on your machine")
   }
@@ -198,7 +199,7 @@ sleuth_prep <- function(
   msg('')
 
   check_result <- check_kal_pack(kal_list)
-  if ( length(check_result$no_bootstrap) > 0 ) {
+  if (length(check_result$no_bootstrap) > 0 ) {
     stop("You must generate bootstraps on all of your samples. Here are the ones that don't contain any:\n",
       paste('\t', kal_dirs[check_result$no_bootstrap], collapse = '\n'))
   }
@@ -208,10 +209,10 @@ sleuth_prep <- function(
   obs_raw <- dplyr::bind_rows(lapply(kal_list, function(k) k$abundance))
 
   design_matrix <- NULL
-  if ( is(full_model, 'formula') ) {
+  if (is(full_model, 'formula') ) {
     design_matrix <- model.matrix(full_model, sample_to_covariates)
   } else {
-    if ( is.null(colnames(full_model)) ) {
+    if (is.null(colnames(full_model)) ) {
       stop("If matrix is supplied, column names must also be supplied.")
     }
     design_matrix <- full_model
@@ -243,7 +244,7 @@ sleuth_prep <- function(
 
   # TODO: eventually factor this out
   normalize <- TRUE
-  if ( normalize ) {
+  if (normalize ) {
 
     msg("normalizing est_counts")
     est_counts_spread <- spread_abundance_by(obs_raw, "est_counts",
@@ -252,7 +253,7 @@ sleuth_prep <- function(
     filter_true <- filter_bool[filter_bool]
 
     msg(paste0(sum(filter_bool), ' targets passed the filter'))
-    est_counts_sf <- norm_fun_counts(est_counts_spread[filter_bool,])
+    est_counts_sf <- norm_fun_counts(est_counts_spread[filter_bool, ])
 
     filter_df <- adf(target_id = names(filter_true))
 
@@ -270,7 +271,7 @@ sleuth_prep <- function(
     msg("normalizing tpm")
     tpm_spread <- spread_abundance_by(obs_raw, "tpm",
       sample_to_covariates$sample)
-    tpm_sf <- norm_fun_tpm(tpm_spread[filter_bool,])
+    tpm_sf <- norm_fun_tpm(tpm_spread[filter_bool, ])
     tpm_norm <- as_df(t(t(tpm_spread) / tpm_sf))
     tpm_norm$target_id <- rownames(tpm_norm)
     tpm_norm <- tidyr::gather(tpm_norm, sample, tpm, -target_id)
@@ -281,11 +282,11 @@ sleuth_prep <- function(
     obs_norm <- dplyr::arrange(obs_norm, target_id, sample)
     tpm_norm <- dplyr::arrange(tpm_norm, target_id, sample)
 
-    stopifnot( all.equal(obs_raw$target_id, obs_norm$target_id) &&
+    stopifnot(all.equal(obs_raw$target_id, obs_norm$target_id) &&
       all.equal(obs_raw$sample, obs_norm$sample) )
 
     suppressWarnings({
-      if ( !all.equal(dplyr::select(obs_norm, target_id, sample),
+      if (!all.equal(dplyr::select(obs_norm, target_id, sample),
           dplyr::select(tpm_norm, target_id, sample)) ) {
         stop('Invalid column rows. In principle, can simply join. Please report error.')
       }
@@ -323,8 +324,8 @@ sleuth_prep <- function(
       bs_summary$obs_counts <- bs_summary$obs_counts[ret$filter_df$target_id, ]
       bs_summary$sigma_q_sq <- bs_summary$sigma_q_sq[ret$filter_df$target_id]
     } else {
-      bs_summary <- gene_summary(ret, aggregation_column, 
-                                 function(x) log(x + 0.5), num_cores=num_cores)
+      bs_summary <- gene_summary(ret, aggregation_column,
+                                 function(x) log(x + 0.5), num_cores = num_cores)
 
         tmp <- ret$obs_raw
         tmp <- dplyr::group_by(tmp, target_id)
@@ -368,14 +369,14 @@ check_kal_pack <- function(kal_list) {
 
   versions <- sapply(kal_list, function(x) attr(x, 'kallisto_version'))
   u_versions <- unique(versions)
-  if ( length(u_versions) > 1) {
+  if (length(u_versions) > 1) {
     warning('More than one version of kallisto was used: ',
       paste(u_versions, collapse = "\n"))
   }
 
   ntargs <- sapply(kal_list, function(x) attr(x, 'num_targets'))
   u_ntargs <- unique(ntargs)
-  if ( length(u_ntargs) > 1 ) {
+  if (length(u_ntargs) > 1 ) {
     stop('Inconsistent number of transcripts. Please make sure you used the same index everywhere.')
   }
 
@@ -436,7 +437,7 @@ check_target_mapping <- function(t_id, target_mapping) {
 #' @export
 norm_factors <- function(mat) {
   nz <- apply(mat, 1, function(row) !any(round(row) == 0))
-  mat_nz <- mat[nz,]
+  mat_nz <- mat[nz, ]
   p <- ncol(mat)
   geo_means <- exp(apply(mat_nz, 1, function(row) mean(log(row)) ))
   s <- sweep(mat_nz, 1, geo_means, `/`)
@@ -669,7 +670,7 @@ summary.sleuth <- function(obj, covariates = TRUE) {
 #' @export
 sleuth_gene_table <- function(obj, test, test_type = 'lrt', which_model = 'full', which_group = 'ens_gene') {
 
-  if(is.null(obj$target_mapping)) {
+  if (is.null(obj$target_mapping)) {
     stop("This sleuth object doesn't have added gene names.")
   }
   popped_gene_table <- sleuth_results(obj, test, test_type, which_model)
@@ -692,9 +693,9 @@ sleuth_gene_table <- function(obj, test, test_type = 'lrt', which_model = 'full'
   filter_empty <- !filter_empty
   popped_gene_table <- popped_gene_table[filter_empty, ]
 
-  # popped_gene_table = popped_gene_table[!popped_gene_table[,1] == "",]
-  # popped_gene_table = popped_gene_table[!is.na(popped_gene_table[,1]),] #gene_id
-  # popped_gene_table = popped_gene_table[!is.na(popped_gene_table$qval),]
+  # popped_gene_table = popped_gene_table[!popped_gene_table[,1] == "", ]
+  # popped_gene_table = popped_gene_table[!is.na(popped_gene_table[,1]), ] #gene_id
+  # popped_gene_table = popped_gene_table[!is.na(popped_gene_table$qval), ]
 
   popped_gene_table
 }
@@ -723,8 +724,8 @@ transcripts_from_gene <- function(obj, test, test_type,
   table <- sleuth_results(obj, test, test_type, which_model)
   table <- dplyr::select_(table, ~target_id, gene_colname, ~qval)
   table <- dplyr::arrange_(table, gene_colname, ~qval)
-  if(!(gene_name %in% table[,2])) {
+  if (!(gene_name %in% table[, 2])) {
       stop("Couldn't find gene ", gene_name)
   }
-  table$target_id[table[,2] == gene_name]
+  table$target_id[table[, 2] == gene_name]
 }

--- a/tests/testthat/test-prep.R
+++ b/tests/testthat/test-prep.R
@@ -25,11 +25,11 @@ test_that("give a design matrix", {
   design_matrix <- matrix(c(0, 0, 0, 1, 1, 1), ncol = 1)
   expect_error(sleuth_prep(study_mapping, design_matrix))
 
-  dimnames(design_matrix) <- list(sample_ids,"condition")
+  dimnames(design_matrix) <- list(sample_ids, "condition")
   result <- sleuth_prep(study_mapping, design_matrix)
 
   expect_equal(result$design_matrix, design_matrix)
   expect_equal(result$design_matrix, result$full_formula)
 
-  expect_error(sleuth_prep(study_mapping, design_matrix[1:5,]))
+  expect_error(sleuth_prep(study_mapping, design_matrix[1:5, ]))
 })

--- a/tests/testthat/test-prep.R
+++ b/tests/testthat/test-prep.R
@@ -23,13 +23,16 @@ test_that("normalization factors", {
 
 test_that("give a design matrix", {
   design_matrix <- matrix(c(0, 0, 0, 1, 1, 1), ncol = 1)
-  expect_error(sleuth_prep(study_mapping, design_matrix))
 
-  dimnames(design_matrix) <- list(sample_ids, "condition")
+  expect_error(result <- sleuth_prep(study_mapping, design_matrix))
+  expect_error(sleuth_prep(study_mapping, design_matrix[1:5,]))
+
+  colnames(design_matrix) <- c('Intercept')
+  rownames(design_matrix) <- study_mapping$sample
+
   result <- sleuth_prep(study_mapping, design_matrix)
 
   expect_equal(result$design_matrix, design_matrix)
   expect_equal(result$design_matrix, result$full_formula)
 
-  expect_error(sleuth_prep(study_mapping, design_matrix[1:5, ]))
 })

--- a/tests/testthat/test-prep.R
+++ b/tests/testthat/test-prep.R
@@ -23,6 +23,9 @@ test_that("normalization factors", {
 
 test_that("give a design matrix", {
   design_matrix <- matrix(c(0, 0, 0, 1, 1, 1), ncol = 1)
+  expect_error(sleuth_prep(study_mapping, design_matrix))
+
+  dimnames(design_matrix) <- list(sample_ids,"condition")
   result <- sleuth_prep(study_mapping, design_matrix)
 
   expect_equal(result$design_matrix, design_matrix)


### PR DESCRIPTION
Hi,

NOTE: This is the same pull request as #93, but I made the mistake of using my master branch instead of a dedicated branch, and unrelated changes got included. I corrected that mistake here.

Below is the same message I included with #93:
--
This is to address issues #80 and #81 that I opened.

For issue #80, gene_summary uses a nested lapply, with the first one using mclapply. This meant that every full bootstrap object was copied to each core. With more than a few samples, this leads to a very large memory footprint (20 samples failed on a machine with 120+ GB of RAM). Using the blogpost I mentioned in #80 as a starting point ([link](https://www.r-bloggers.com/trying-to-reduce-the-memory-overhead-when-using-mclapply/)), I switched the use of mclapply to the second nested lapply, so that only individual bootstraps will be sent out to each core. This significantly reduces the memory footprint.

For issue #81, I wanted to take full advantage of a machine that had more than 2 cores, so I simply added the option to gene_summary and then to sleuth_prep, updated the documentation for sleuth_prep, and added test conditions to make sure the choice of num_cores was reasonable, throwing an informative error if it is not.

Finally, I followed your contribution guidelines to make the code lintr clean. In the process of making sure my updated code passed all of your tests, I found that one of your tests ("give a design matrix") had a bug, so I fixed it to make sure it worked.

Hope this helps!
Warren