### PR TITLE
Add gene annotations when using "sleuth_results", addressing #86

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -330,6 +330,22 @@ sleuth_results <- function(obj, test, test_type = 'wt',
       data.table::as.data.table(obj$target_mapping),
       by = 'target_id')
   }
+
+  if (!is.null(obj$target_mapping) && obj$gene_mode) {
+    # after removing the target_id column
+    # there are several redundant columns for each gene
+    # this line gets the unique line for each gene
+    target_mapping <- unique(dplyr::select(
+                               obj$target_mapping,
+                               -target_id))
+    # this line uses dplyr's "left_join" syntax for "by"
+    # to match "target_id" from the "res" table,
+    # and the gene_column from the target_mapping table.
+    res <- dplyr::left_join(data.table::as.data.table(res),
+                            data.table::as.data.table(target_mapping),
+                            by = c("target_id" = obj$gene_column))
+  }
+
   res <- as_df(res)
 
   dplyr::arrange(res, qval)


### PR DESCRIPTION
Hi sleuth team,

I have added a small bit of code to address #86, where a user noticed that no annotations were included in the results table after using `aggregation_column` then `sleuth_results`. 

The code first removes the target_id column (the "transcripts") from the `target_mapping` table, and then reduces it down to unique rows: one for each "gene" (aggregation_column).
The code then uses dplyr's `left_join` to put them together, using the syntax for `by` to join two different columns (`target_id` in the results table, and `obj$gene_column` for the reduced target_mapping table).

Because lintr is currently disabled and the "give a design matrix" test is broken on the master branch, I didn't bother making those changes again. I tried to make sure the added was lintr clean. I don't think additional tests are necessary for this additional code, because the necessary checks are done during `sleuth_prep`.

Let me know if you have any feedback!