### PR TITLE
use grave accents ` to allow any sample name for plot_scatter

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -438,19 +438,22 @@ plot_scatter <- function(obj,
   abund <- dplyr::mutate(abund, target_id = rownames(abund))
 
   if (!is.null(trans)) {
-    sample_x <- paste0( trans, '( ', sample_x)
-    sample_y <- paste0( trans, '( ', sample_y)
+    sample_x <- paste0( trans, '( `', sample_x)
+    sample_y <- paste0( trans, '( `', sample_y)
   }
 
   if ( (!is.null(offset) && !is.na(offset)) && offset != 0 ) {
     off <- deparse(eval(offset))
-    sample_x <- paste0(sample_x, ' + ', off)
-    sample_y <- paste0(sample_y, ' + ', off)
+    sample_x <- paste0(sample_x, '` + ', off)
+    sample_y <- paste0(sample_y, '` + ', off)
   }
 
-  if (!is.null(trans)) {
+  if (!is.null(trans) and !is.null(offset)) {
     sample_x <- paste0(sample_x, ' )')
     sample_y <- paste0(sample_y, ' )')
+  } else {
+    sample_x <- paste0(sample_x, '` )')
+    sample_y <- paste0(sample_y, '` )')
   }
 
   p <- ggplot(abund, aes_string(sample_x, sample_y))

--- a/R/plots.R
+++ b/R/plots.R
@@ -448,7 +448,7 @@ plot_scatter <- function(obj,
     sample_y <- paste0(sample_y, '` + ', off)
   }
 
-  if (!is.null(trans) and !is.null(offset)) {
+  if (!is.null(trans) & !is.null(offset)) {
     sample_x <- paste0(sample_x, ' )')
     sample_y <- paste0(sample_y, ' )')
   } else {


### PR DESCRIPTION
Hi,

In `plot_scatter`, `aes_string` from `ggplot2` is used to take the log of the normalized counts for the scatter plot using the sample name as an expression. However, sample names that would cause a syntax error (e.g. using hyphens, which are interpreted as minus signs) cause an error unless the grave accent ' \` ' is used (this is the source of the error in #89).

I'm not sure if there is another case where this proposed code would break when the original wouldn't (maybe check to make sure the sample names exist in the `sample_to_covariates` table?), but here is the proposed solution.

Best,
Warren