### PR TITLE
Fix dplyr grouping warning (#102)

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -54,9 +54,10 @@ sliding_window_grouping <- function(data, x_col, y_col,
   data <- group_by(data, x_group)
 
   res <- do(data, get_quantile(., y_col, lwr, upr, ignore_zeroes))
+  res <- ungroup(res)
   res <- select(res, -c(x_ecdf, x_group))
 
-  ungroup(res)
+  res
 }
 
 #' @export


### PR DESCRIPTION
Hey @pimentel,

I noticed the warning described in #102 too. I discovered it was caused by removing the grouping column `x_group` before ungrouping in `sliding_window_grouping`, so dplyr gives a warning because it expects the groups to always be present. I found this out from this [stackoverflow thread](https://stackoverflow.com/questions/38511743/adding-missing-grouping-variables-message-in-dplyr-in-r)

This should fix the problem.