### PR TITLE
address #113 - patch bug where TPM bootstrap summary target_ids are moved

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -398,6 +398,7 @@ process_bootstrap <- function(i, samp_name, kal_path,
   if (read_bootstrap_tpm) {
     bs_quant_tpm <- aperm(apply(bs_mat, 1, counts_to_tpm,
                                 eff_len))
+    colnames(bs_quant_tpm) <- colnames(bs_mat)
 
     # gene level code is analogous here to below code
     if (gene_mode) {


### PR DESCRIPTION
Hi @pimentel,

To address #113, I realized that the error occurs because the TPM bootstrap summary object in `bs_quants` has no rownames, so no target_ids will be found. I further discovered that target_ids are removed from the tpm bootstrap summary object after the `counts_to_tpm` step in `process_bootstrap`. I've made a patch that makes sure that the target_ids remain. This should fix the issue.