### PR TITLE
Possible solution to NAs in sleuth_lrt, addressing #68

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -86,7 +86,7 @@ shrink_df <- function(data, shrink_formula, filter_var) {
               " due to mean observation values outside of the range used for the LOESS fit.\n",
               "The LOESS fit will be repeated using exact computation of the fitted ",
               "surface to extrapolate the missing values.\n",
-              "These are the target ids with NA values: ", paste(which_na))
+              "These are the target ids with NA values: ", paste(which_na, collapse = ", "))
       direct_fit <- eval(loess(s_formula, data[data[, filter_var], ], model = T,
                   control = loess.control(surface = "direct")))
       na_data <- data[na_rows, ]
@@ -102,7 +102,7 @@ shrink_df <- function(data, shrink_formula, filter_var) {
               " due to an unknown cause. These values will result in NAs ",
               "with any downstream testing for these target ids.\n",
               "Please submit a bug report at the Sleuth Github website.\n",
-              "These are the target ids with NA values: ", paste(which_na))
+              "These are the target ids with NA values: ", paste(which_na, collapse = ", "))
     }
   }
   shrink_data

--- a/R/misc.R
+++ b/R/misc.R
@@ -70,7 +70,7 @@ shrink_df <- function(data, shrink_formula, filter_var) {
   # include a column to report any target IDs that failed shrinkage estimation
   # 'failed_ise' is short for 'failed initial shrinkage estimation'
   shrink_data$failed_ise <- is.na(shrink_data$shrink)
-  if (any(shrink_data$failed_ise))) {
+  if (any(shrink_data$failed_ise)) {
     na_rows <- which(shrink_data$failed_ise)
     num_na <- length(na_rows)
     which_na <- shrink_data$target_id[na_rows]

--- a/R/misc.R
+++ b/R/misc.R
@@ -64,8 +64,44 @@ sliding_window_grouping <- function(data, x_col, y_col,
 shrink_df <- function(data, shrink_formula, filter_var) {
   data <- as.data.frame(data)
   s_formula <- substitute(shrink_formula)
-  fit <- eval(loess(s_formula, data[data[, filter_var], ]))
-  data.frame(data, shrink = predict(fit, data))
+  fit <- eval(loess(s_formula, data[data[, filter_var], ], model = T))
+  shrink_data <- data.frame(data, shrink = predict(fit, data))
+
+  if (any(is.na(shrink_data$shrink))) {
+    num_na <- length(which(is.na(shrink_data$shrink)))
+    which_na <- shrink_data$target_id[is.na(shrink_data$shrink)]
+    max_mean_obs <- summary(fit$model$mean_obs)["Max."]
+    min_mean_obs <- summary(fit$model$mean_obs)["Min."]
+    # check for mean_obs values that fall outside of the window that
+    # was used to fit the LOESS curve. If any values do fall outside,
+    # repeat the LOESS fit using "surface = direct" to get an exact surface fit,
+    # which can then be used for extrapolation of these values.
+    if (any(shrink_data$mean_obs > max_mean_obs |
+            shrink_data$mean_obs < min_mean_obs)) {
+      message(num_na, " NA values were found during variance shrinkage estimation",
+              " due to mean observation values outside of the range used for the LOESS fit.\n",
+              "The LOESS fit will be repeated using exact computation of the fitted ",
+              "surface to extrapolate the missing values.\n",
+              "These are the target ids with NA values: ", paste(which_na))
+      direct_fit <- eval(loess(s_formula, data[data[, filter_var], ], model = T,
+                  control = loess.control(surface = "direct")))
+      na_data <- data[which(data$target_id %in% which_na), ]
+      na_shrink_data <- data.frame(na_data, shrink = predict(direct_fit, na_data))
+      shrink_data[which(shrink_data$target_id %in% which_na), "shrink"] <- na_shrink_data$shrink
+    }
+    # repeat the check for NA values; if there were no values outside of the mean_obs window used
+    # (first check above) or if there were new NA values from the direct fit, then
+    # the cause of the NA values is unknown. The user will be warned that this will cause
+    # all downstream testing to fail for these target IDs.
+    if (any(is.na(shrink_data$shrink))) {
+      stop(num_na, " NA values were found during variance shrinkage estimation",
+              " due to an unknown cause. These values will result in NAs ",
+              "with any downstream testing for these target ids.\n",
+              "Please submit a bug report at the Sleuth Github website.\n",
+              "These are the target ids with NA values: ", paste(which_na))
+    }
+  }
+  shrink_data
 }
 
 msg <- function(..., nl = TRUE) {


### PR DESCRIPTION
Hi @pimentel,

Great work with the new release and all of the patches! Last suggestion from me before I turn it in for the weekend (I won't be available this weekend or all next week). As I commented in #68, I think the issue with `NAs` has to do with some target ids having mean observed counts outside of the bounds used to create the LOESS fit. The standard fit can't be extrapolated, which is what results in the `NAs`.

This is code that would attempt to pursue option 4, which is to produce an extrapolated value using the LOESS fit with `surface = "direct"` option. According to the documentation and my testing, the values can be extrapolated to the target ids that otherwise would have `NAs`. However, because the exact computation for the surface fit is much more expensive, I only recompute the fits for the target ids that are `NA`.

I also included a message that would let the user know when this occurs, and a column is included with the `sleuth_object$fits[[fit_name]]$summary` `data.frame` that indicates which `target_ids` failed the initial shrinkage estimation (abbreviated `failed_ise`), in case they want to follow-up or exclude those `target_ids`.

Let me know what you think!
