### PR TITLE
Fix behavior of sleuth_results when gene_mode is TRUE (and error reporting)

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -398,24 +398,7 @@ sleuth_results <- function(obj, test, test_type = 'wt',
       data.table::as.data.table(obj$target_mapping),
       data.table::as.data.table(res),
       by = 'target_id')
-  }
-
-  if ( pval_aggregate ) {
-  	if (is.null(obj$target_mapping) ) {
-  			stop('Must provide transcript to gene mapping table in order to aggregate p-values')
-  	}
-    res <- data.table::as.data.table(res)
-    res <- res[, .(
-    	num_aggregated_transcripts = length(!is.na(pval)),
-    	sum_mean_obs_counts = sum(mean_obs, na.rm=TRUE),
-    	pval = as.numeric(aggregation::lancaster(pval, mean_obs))),
-		by=eval(obj$gene_column)]
-
-	res <- res[, qval:=p.adjust(pval, 'BH')]
-	res <- as_df(res)
-  }
-
-  if (show_all && !is.null(obj$target_mapping) && obj$gene_mode) {
+  } else if (!is.null(obj$target_mapping) && obj$gene_mode) {
     # after removing the target_id column
     # there are several redundant columns for each gene
     # this line gets the unique line for each gene
@@ -431,6 +414,21 @@ sleuth_results <- function(obj, test, test_type = 'wt',
                             data.table::as.data.table(res),
                             by = by_col)
     names(res)[1] <- "target_id"
+  }
+
+  if ( pval_aggregate ) {
+  	if (is.null(obj$target_mapping) ) {
+  			stop('Must provide transcript to gene mapping table in order to aggregate p-values')
+  	}
+    res <- data.table::as.data.table(res)
+    res <- res[, .(
+    	num_aggregated_transcripts = length(!is.na(pval)),
+    	sum_mean_obs_counts = sum(mean_obs, na.rm=TRUE),
+    	pval = as.numeric(aggregation::lancaster(pval, mean_obs))),
+		by=eval(obj$gene_column)]
+
+	res <- res[, qval:=p.adjust(pval, 'BH')]
+	res <- as_df(res)
   }
 
   res <- as_df(res)

--- a/R/model.R
+++ b/R/model.R
@@ -418,7 +418,8 @@ sleuth_results <- function(obj, test, test_type = 'wt',
 
   if ( pval_aggregate ) {
   	if (is.null(obj$target_mapping) ) {
-  			stop('Must provide transcript to gene mapping table in order to aggregate p-values')
+  			stop('Must provide transcript to gene mapping table in order to aggregate p-values. ',
+                             'Please rerun "sleuth_prep" using the "target_mapping" argument.')
   	}
     res <- data.table::as.data.table(res)
     res <- res[, .(


### PR DESCRIPTION
Hi @pimentel,

This may not be relevant with `gene_mode` hidden now, but I noticed that I had previously based adding gene metadata when `gene_mode = TRUE` only when `show_all = TRUE`, which isn't technically correct. I fixed this behavior.

I also took this opportunity to improve the error reporting for the case when `pval_aggregation` is requested, but a `target_mapping` is missing, to make clear to the user what they need to do. 