### PR TITLE
fix double-negation in gene_column check upon manual change of pval_aggregate in sleuth_object

### DIFF
--- a/R/sleuth.R
+++ b/R/sleuth.R
@@ -1291,7 +1291,7 @@ gene_from_gene <- function(obj, gene_colname, gene_name) {
     } else {
       obj[[name]] <- value
     }
-  } else if (name == "pval_aggregate" && value && !is.null(obj$gene_column)) {
+  } else if (name == "pval_aggregate" && value && is.null(obj$gene_column)) {
     stop("You set 'pval_aggregate' to TRUE, but no 'gene_column' is set. Please set a 'gene_column' first.")
   } else if (name == "pval_aggregate" && value && obj$gene_mode) {
     warning("You set 'pval_aggregate' to TRUE, but 'gene_mode' is also TRUE. Setting 'gene_mode' to FALSE.",


### PR DESCRIPTION
The changed code would previously stop with an error, if you assigned the value `TRUE` to `pval_aggregate` in a sleuth object with the `gene_column` defined, contrary to the error message given. @AntonieV and I stumbled upon this, and believe this is merely an unintended double-negation in the `if`-clause.